### PR TITLE
Fixed Issue with polymorphic relations

### DIFF
--- a/lib/active_record_union/active_record/relation/union.rb
+++ b/lib/active_record_union/active_record/relation/union.rb
@@ -41,7 +41,7 @@ module ActiveRecord
         )
 
         relation = @klass.unscoped.from(from)
-        relation.bind_values = self.bind_values + self.arel.bind_values + other.bind_values + other.arel.bind_values
+        relation.bind_values = self.arel.bind_values + self.bind_values + other.arel.bind_values + other.bind_values
         relation
       end
 

--- a/lib/active_record_union/active_record/relation/union.rb
+++ b/lib/active_record_union/active_record/relation/union.rb
@@ -41,7 +41,7 @@ module ActiveRecord
         )
 
         relation = @klass.unscoped.from(from)
-        relation.bind_values = self.bind_values + other.bind_values
+        relation.bind_values = self.bind_values + self.arel.bind_values + other.bind_values + other.arel.bind_values
         relation
       end
 


### PR DESCRIPTION
Addresses an issue where doing a union with polymorphic relationships fails with error:

`ActiveRecord::StatementInvalid: PG::ProtocolViolation: ERROR:  bind message supplies 0 parameters, but prepared statement "" requires 2`

Steps to reproduce

```
class Picture < ActiveRecord::Base
  belongs_to :imageable, polymorphic: true
end
 
class Employee < ActiveRecord::Base
  has_many :pictures, as: :imageable
end
 
class Product < ActiveRecord::Base
  has_many :pictures, as: :imageable
end

Employee.joins(:pictures).select(:name).union(Product.joins(:pictures).select(:name))  <--- fails
```

See Also: https://github.com/brianhempel/active_record_union/issues/5 