### PR TITLE
Rails 5.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,10 @@ language: ruby
 addons:
   postgresql: "9.4"
 rvm:
-  - 2.3.1
-  - 2.2.5
-  - 2.1.8
-  - 2.0.0
+  - 2.3.6
 gemfile:
   - rails_4_2.gemfile
   - rails_5_0.gemfile
-matrix:
-  exclude:
-  # Rails 5 requires Ruby 2.2+:
-  - rvm: 2.1.8
-    gemfile: rails_5_0.gemfile
-  - rvm: 2.0.0
-    gemfile: rails_5_0.gemfile
+  - rails_5_1.gemfile
+  - rails_5_2.gemfile
 script: bundle exec rspec

--- a/lib/active_record_union/active_record/relation/union.rb
+++ b/lib/active_record_union/active_record/relation/union.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       private
 
       def set_operation(operation, relation_or_where_arg, *args)
-        other = if args.size == 0 && Relation === relation_or_where_arg
+        other = if args.empty? && relation_or_where_arg.is_a?(Relation)
                   relation_or_where_arg
                 else
                   @klass.where(relation_or_where_arg, *args)
@@ -26,24 +26,56 @@ module ActiveRecord
 
         verify_relations_for_set_operation!(operation, self, other)
 
+        left = self.arel.ast
+        right = other.arel.ast
+
         # Postgres allows ORDER BY in the UNION subqueries if each subquery is surrounded by parenthesis
-        # but SQLite does not allow parens around the subqueries; you will have to explicitly do `relation.reorder(nil)` in SQLite
-        if Arel::Visitors::SQLite === self.connection.visitor
-          left, right = self.ast, other.ast
-        else
-          left, right = Arel::Nodes::Grouping.new(self.ast), Arel::Nodes::Grouping.new(other.ast)
+        # but SQLite does not allow parens around the subqueries
+        unless self.connection.visitor.is_a?(Arel::Visitors::SQLite)
+          left = Arel::Nodes::Grouping.new(left)
+          right = Arel::Nodes::Grouping.new(right)
         end
 
         set  = SET_OPERATION_TO_AREL_CLASS[operation].new(left, right)
         from = Arel::Nodes::TableAlias.new(set, @klass.arel_table.name)
-        if ActiveRecord::VERSION::MAJOR >= 5
-          relation             = @klass.unscoped.spawn
-          relation.from_clause = UnionFromClause.new(from, nil, self.bound_attributes + other.bound_attributes)
-        else
-          relation             = @klass.unscoped.from(from)
-          relation.bind_values = self.arel.bind_values + self.bind_values + other.arel.bind_values + other.bind_values
+        build_union_relation(from, other)
+      end
+
+      if ActiveRecord.gem_version >= Gem::Version.new('5.2.0.beta2')
+        # Since Rails 5.2, binds are maintained only in the Arel AST.
+        def build_union_relation(arel_table_alias, _other)
+          @klass.unscoped.from(arel_table_alias)
         end
-        relation
+      elsif ActiveRecord::VERSION::MAJOR >= 5
+        # In Rails >= 5.0, < 5.2, binds are maintained only in ActiveRecord
+        # relations and clauses.
+        def build_union_relation(arel_table_alias, other)
+          relation = @klass.unscoped.spawn
+          relation.from_clause =
+            UnionFromClause.new(arel_table_alias, nil,
+                                self.bound_attributes + other.bound_attributes)
+          relation
+        end
+
+        class UnionFromClause < ActiveRecord::Relation::FromClause
+          def initialize(value, name, bound_attributes)
+            super(value, name)
+            @bound_attributes = bound_attributes
+          end
+
+          def binds
+            @bound_attributes
+          end
+        end
+      else
+        # In Rails 4.x, binds are maintained in both ActiveRecord relations and
+        # clauses and also in their Arel ASTs.
+        def build_union_relation(arel_table_alias, other)
+          relation = @klass.unscoped.from(arel_table_alias)
+          relation.bind_values = self.arel.bind_values + self.bind_values +
+                                 other.arel.bind_values + other.bind_values
+          relation
+        end
       end
 
       def verify_relations_for_set_operation!(operation, *relations)
@@ -61,19 +93,6 @@ module ActiveRecord
         eager_load_relations = relations.select { |r| r.eager_load_values.any? }
         if eager_load_relations.any?
           raise ArgumentError.new("Cannot #{operation} relation with eager load.")
-        end
-      end
-
-      if ActiveRecord::VERSION::MAJOR >= 5
-        class UnionFromClause < ActiveRecord::Relation::FromClause
-          def initialize(value, name, bound_attributes)
-            super(value, name)
-            @bound_attributes = bound_attributes
-          end
-
-          def binds
-            @bound_attributes
-          end
         end
       end
     end

--- a/rails_4_2.gemfile
+++ b/rails_4_2.gemfile
@@ -4,3 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rails', '~> 4.2.7'
+
+# On Rails < 5.2, only pg < v1 is supported. See:
+# https://github.com/rails/rails/pull/31671
+# https://bitbucket.org/ged/ruby-pg/issues/270/pg-100-x64-mingw32-rails-server-not-start
+gem 'pg', '~> 0.21'

--- a/rails_5_1.gemfile
+++ b/rails_5_1.gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in active_record_union.gemspec
 gemspec
 
-gem 'rails', '~> 5.0.0'
+gem 'rails', '~> 5.1.0'
 
 # On Rails < 5.2, only pg < v1 is supported. See:
 # https://github.com/rails/rails/pull/31671

--- a/rails_5_2.gemfile
+++ b/rails_5_2.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in active_record_union.gemspec
+gemspec
+
+# pg v1.0+ compatibility, https://github.com/rails/rails/pull/31671:
+gem 'rails', '~> 5.2.0.beta2', git: 'https://github.com/rails/rails', ref: 'f1af27fd9d9101684b26d0dcf2028859d67bec1f'

--- a/spec/union_spec.rb
+++ b/spec/union_spec.rb
@@ -41,7 +41,11 @@ describe ActiveRecord::Relation do
     end
 
     def bind_values_from_relation(relation)
-      if ActiveRecord::VERSION::MAJOR >= 5
+      if ActiveRecord.gem_version >= Gem::Version.new('5.2.0.beta2')
+        relation.arel_table.class.engine.connection.visitor.accept(
+          relation.arel.ast, Arel::Collectors::Bind.new
+        ).value.map(&:value)
+      elsif ActiveRecord::VERSION::MAJOR >= 5
         relation.bound_attributes.map { |a| a.value_for_database }
       else
         (relation.arel.bind_values + relation.bind_values).map { |_column, value| value }

--- a/spec/union_spec.rb
+++ b/spec/union_spec.rb
@@ -126,10 +126,8 @@ describe ActiveRecord::Relation do
       context "in MySQL" do
         it "wraps query subselects in parentheses to allow ORDER BY clauses" do
           Databases.with_mysql do
-            # TODO: investigate why this is different to SQL_TIME on Rails 4
-            sql_time = '2014-07-19 00:00:00'
             expect(union.to_sql.squish).to eq(
-              "SELECT `posts`.* FROM ( (SELECT `posts`.* FROM `posts` WHERE `posts`.`user_id` = 1 ORDER BY `posts`.`created_at` ASC) UNION (SELECT `posts`.* FROM `posts` WHERE (created_at > '#{sql_time}') ORDER BY `posts`.`created_at` ASC) ) `posts` ORDER BY `posts`.`created_at` ASC"
+              "SELECT `posts`.* FROM ( (SELECT `posts`.* FROM `posts` WHERE `posts`.`user_id` = 1 ORDER BY `posts`.`created_at` ASC) UNION (SELECT `posts`.* FROM `posts` WHERE (created_at > '#{SQL_TIME}') ORDER BY `posts`.`created_at` ASC) ) `posts` ORDER BY `posts`.`created_at` ASC"
             )
             expect{union.to_a}.to_not raise_error
           end


### PR DESCRIPTION
Since Rails 5.2, binds are maintained only in the Arel AST.